### PR TITLE
MT-1939-fix-hashed-credential-conversion

### DIFF
--- a/Sources/FirebaseConstants.swift
+++ b/Sources/FirebaseConstants.swift
@@ -16,7 +16,7 @@ enum FirebaseConstants {
     static let commandId = "firebaseAnalytics"
     static let description = "Firebase Remote Command"
     static let errorPrefix = "Tealium Firebase: "
-    static let version = "4.0.0"
+    static let version = "4.0.1"
     
     enum Keys {
         static let sessionTimeout = "firebase_session_timeout_seconds"

--- a/Sources/FirebaseInstance.swift
+++ b/Sources/FirebaseInstance.swift
@@ -27,7 +27,7 @@ public protocol FirebaseCommand {
     func setUserId(_ id: String)
     func initiateOnDeviceConversionMeasurement(emailAddress: String)
     func initiateOnDeviceConversionMeasurement(phoneNumber: String)
-    func initiateOnDeviceConversionMeasurement(hashedEmailAdress: Data)
+    func initiateOnDeviceConversionMeasurement(hashedEmailAddress: Data)
     func initiateOnDeviceConversionMeasurement(hashedPhoneNumber: Data)
     func setDefaultEventParameters(parameters: [String: Any]?)
     func setConsent(_ consentSettings: [String: String])
@@ -135,9 +135,9 @@ public class FirebaseInstance: FirebaseCommand {
         }
     }
     
-    public func initiateOnDeviceConversionMeasurement(hashedEmailAdress: Data) {
+    public func initiateOnDeviceConversionMeasurement(hashedEmailAddress: Data) {
         onReady {
-            Analytics.initiateOnDeviceConversionMeasurement(hashedEmailAddress: hashedEmailAdress)
+            Analytics.initiateOnDeviceConversionMeasurement(hashedEmailAddress: hashedEmailAddress)
         }
     }
     

--- a/Sources/FirebaseRemoteCommand.swift
+++ b/Sources/FirebaseRemoteCommand.swift
@@ -127,16 +127,18 @@ public class FirebaseRemoteCommand: RemoteCommand {
                 }
                 firebaseInstance.setUserId(userId)
             case .initiateConversionMeasurement:
-                if let hashedEmailAddress = payload[FirebaseConstants.Keys.hashedEmailAddress] as? String {
-                    firebaseInstance.initiateOnDeviceConversionMeasurement(hashedEmailAdress: Data(hashedEmailAddress.utf8))
-                } else if let hashedPhoneNumber = payload[FirebaseConstants.Keys.hashedPhoneNumber] as? String {
-                    firebaseInstance.initiateOnDeviceConversionMeasurement(hashedPhoneNumber: Data(hashedPhoneNumber.utf8))
+                if let hashedEmailAddress = payload[FirebaseConstants.Keys.hashedEmailAddress] as? String,
+                   let data = Data(base64Encoded: hashedEmailAddress) {
+                    firebaseInstance.initiateOnDeviceConversionMeasurement(hashedEmailAddress: data)
+                } else if let hashedPhoneNumber = payload[FirebaseConstants.Keys.hashedPhoneNumber] as? String,
+                          let data = Data(base64Encoded: hashedPhoneNumber) {
+                    firebaseInstance.initiateOnDeviceConversionMeasurement(hashedPhoneNumber: data)
                 } else if let emailAddress = payload[FirebaseConstants.Keys.emailAddress] as? String {
                     firebaseInstance.initiateOnDeviceConversionMeasurement(emailAddress: emailAddress)
                 } else if let phoneNumber = payload[FirebaseConstants.Keys.phoneNumber] as? String {
                     firebaseInstance.initiateOnDeviceConversionMeasurement(phoneNumber: phoneNumber)
                 } else if firebaseLogLevel == .debug {
-                    print("\(FirebaseConstants.errorPrefix) one of the following: `\(FirebaseConstants.Keys.emailAddress)`, `\(FirebaseConstants.Keys.phoneNumber)`,`\(FirebaseConstants.Keys.hashedEmailAddress)`, `\(FirebaseConstants.Keys.phoneNumber) is required for \(command).")
+                    print("\(FirebaseConstants.errorPrefix) one of the following: `\(FirebaseConstants.Keys.emailAddress)`, `\(FirebaseConstants.Keys.phoneNumber)`,`\(FirebaseConstants.Keys.hashedEmailAddress)`, `\(FirebaseConstants.Keys.hashedPhoneNumber)` is required for \(command).")
                 }
             case .setDefaultParameters:
                 let params = payload[FirebaseConstants.Keys.defaultParams] as? [String: Any]

--- a/TealiumFirebase.podspec
+++ b/TealiumFirebase.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
     # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
     s.name         = "TealiumFirebase"
     s.module_name  = "TealiumFirebase"
-    s.version      = "4.0.0"
+    s.version      = "4.0.1"
     s.summary      = "Tealium Swift and Firebase integration"
     s.description  = <<-DESC
     Tealium's integration with Firebase for iOS.

--- a/TealiumFirebaseExample/Podfile.lock
+++ b/TealiumFirebaseExample/Podfile.lock
@@ -101,7 +101,7 @@ PODS:
     - tealium-swift/Core
   - tealium-swift/TagManagement (2.18.0):
     - tealium-swift/Core
-  - TealiumFirebase (4.0.0):
+  - TealiumFirebase (4.0.1):
     - Firebase (~> 12.0)
     - FirebaseAnalytics (~> 12.0)
     - tealium-swift/Core (~> 2.18)
@@ -142,7 +142,7 @@ SPEC CHECKSUMS:
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   tealium-swift: 891b7d27a4aa3e8b3c7398ac536382526ad215fc
-  TealiumFirebase: 12bb9dbd090738fcd7bc6ebff4b2f1a7a3485351
+  TealiumFirebase: 229b2b9773644b93344dbebb898d6c552567b801
 
 PODFILE CHECKSUM: 0e74b5b01f7119f8386a0628d0ed4a825aa7fedf
 

--- a/Tests/FirebaseInstanceTests.swift
+++ b/Tests/FirebaseInstanceTests.swift
@@ -158,22 +158,37 @@ class FirebaseInstanceTests: XCTestCase {
         XCTAssertEqual(1, firebaseInstance.initateConversionCount)
     }
     
+    // SHA256 hashes must arrive as base64-encoded 32-byte Data.
+    // 32 zero bytes encoded as base64 (used as a stand-in for a real SHA256 hash in tests).
+    private let validHashedEmail = Data(repeating: 0, count: 32).base64EncodedString()
+    private let validHashedPhone = Data(repeating: 1, count: 32).base64EncodedString()
+
     func testInitiateConversionMeasurementWithHashEmail() {
-        let payload: [String: Any] = ["command_name": "initiateconversionmeasurement", "param_hashed_email_address": "normalised_email"]
+        let payload: [String: Any] = ["command_name": "initiateconversionmeasurement", "param_hashed_email_address": validHashedEmail]
         firebaseCommand.processRemoteCommand(with: payload)
         XCTAssertEqual(1, firebaseInstance.initateConversionCount)
+        XCTAssertEqual(firebaseInstance.lastHashedEmailData, Data(repeating: 0, count: 32))
     }
-    
+
     func testInitiateConversionMeasurementWithHashPhone() {
-        let payload: [String: Any] = ["command_name": "initiateconversionmeasurement", "param_hashed_phone_number": "normalised_phone"]
+        let payload: [String: Any] = ["command_name": "initiateconversionmeasurement", "param_hashed_phone_number": validHashedPhone]
+        firebaseCommand.processRemoteCommand(with: payload)
+        XCTAssertEqual(1, firebaseInstance.initateConversionCount)
+        XCTAssertEqual(firebaseInstance.lastHashedPhoneData, Data(repeating: 1, count: 32))
+    }
+
+    func testInitiateConversionMeasurementWithValues() {
+        // Priority: hashed_email > hashed_phone > email > phone — only first match fires.
+        let payload: [String: Any] = ["command_name": "initiateconversionmeasurement", "param_email_address": "email@domain.com", "param_phone_number": "+444444444444", "param_hashed_email_address": validHashedEmail, "param_hashed_phone_number": validHashedPhone]
         firebaseCommand.processRemoteCommand(with: payload)
         XCTAssertEqual(1, firebaseInstance.initateConversionCount)
     }
-    
-    func testInitiateConversionMeasurementWithValues() {
-        let payload: [String: Any] = ["command_name": "initiateconversionmeasurement", "param_email_address": "email@domain.com", "param_phone_number": "+444444444444", "param_hashed_email_address": "normalised_email", "param_hashed_phone_number": "normalised_phone"]
+
+    func testInitiateConversionMeasurementWithInvalidBase64HashEmail() {
+        // A plain hex string (not base64) must not be passed to Firebase.
+        let payload: [String: Any] = ["command_name": "initiateconversionmeasurement", "param_hashed_email_address": "notvalidbase64!!!"]
         firebaseCommand.processRemoteCommand(with: payload)
-        XCTAssertEqual(1, firebaseInstance.initateConversionCount)
+        XCTAssertEqual(0, firebaseInstance.initateConversionCount)
     }
     
     func testInitiateConversionMeasurementWithoutValues() {

--- a/Tests/MockFirebaseInstance.swift
+++ b/Tests/MockFirebaseInstance.swift
@@ -37,6 +37,9 @@ class MockFirebaseInstance: FirebaseInstance {
     var setUserIdCallCount = 0
     
     var initateConversionCount = 0
+
+    var lastHashedEmailData: Data?
+    var lastHashedPhoneData: Data?
     
     var defaultParameters: [String:Any]?
 
@@ -77,12 +80,14 @@ class MockFirebaseInstance: FirebaseInstance {
         initateConversionCount += 1
     }
     
-    override func initiateOnDeviceConversionMeasurement(hashedEmailAdress: Data) {
+    override func initiateOnDeviceConversionMeasurement(hashedEmailAddress: Data) {
         initateConversionCount += 1
+        lastHashedEmailData = hashedEmailAddress
     }
     
     override func initiateOnDeviceConversionMeasurement(hashedPhoneNumber: Data) {
         initateConversionCount += 1
+        lastHashedPhoneData = hashedPhoneNumber
     }
     
     override func setDefaultEventParameters(parameters: [String : Any]?) {


### PR DESCRIPTION
fix: decode hashed credentials as base64 for on-device conversion measurement

Data(string.utf8) was producing 64 bytes of ASCII instead of the
32-byte raw SHA256 required by Firebase, causing silent rejection
with log [I-ACS025056].

Switch to Data(base64Encoded:) to correctly decode the payload
string into raw bytes before passing to Firebase. Also fix the
longstanding typo hashedEmailAdress → hashedEmailAddress in the
FirebaseCommand protocol, FirebaseInstance, and MockFirebaseInstance.